### PR TITLE
Make PDP urls to match current

### DIFF
--- a/apps/pdp/pages/index.js
+++ b/apps/pdp/pages/index.js
@@ -26,9 +26,17 @@ function Index(props) {
 Index.getInitialProps = async ({ query, asPath, pathname, res }) => {
   const { slug } = query;
   const surrogateKey = pathname.replace("/", "");
-  let product = {};
+  let productName = slug.replace(/-/g, " ");
+  let gender = "";
+  if (slug.indexOf("womens") > -1) {
+    gender = " women's";
+    productName = productName.replace("womens/", "");
+  } else if (slug.indexOf("mens") > -1) {
+    gender = " men's";
+    productName = productName.replace("mens/", "");
+  }
 
-  product = await getProductData(slug);
+  const product = await getProductData(`${productName}${gender}`);
 
   if (product == null) {
     if (res) {


### PR DESCRIPTION
With this commit can now use local.arcteryx.com/ca/en/shop/mens/atom-lt-hoody, local.arcteryx.com/ca/en/shop/womens/atom-lt-hoody or local.arcteryx.com/ca/en/shop/axe-keeper